### PR TITLE
Consumers set their own paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 ```bash
 $ npm install -g tsviz
 ```
-You also need to install [GraphViz](http://www.graphviz.org/Download.php)
+You also need to install [GraphViz](http://www.graphviz.org/Download.php), including correctly added it to your OS' PATH.
 
 ## Usage
 
-In order to create a diagram for an entire project you simply type: 
+In order to create a diagram for an entire project you simply type:
 
 ```bash
 $ tsviz samples/ diagram.png

--- a/bin/uml-builder.js
+++ b/bin/uml-builder.js
@@ -25,9 +25,6 @@ function buildUml(modules, outputFilename, dependenciesOnly, svgOutput) {
             console.warn("Could not find Graphviz in PATH.");
         }
     }
-    else {
-        g.setGraphVizPath("/usr/local/bin");
-    }
     g.output(svgOutput ? "svg" : "png", outputFilename);
 }
 exports.buildUml = buildUml;

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "dependencies": {
     "graphviz": ">=0.0.8",
     "typescript": "=1.8.10"
-  }
+  },
+  "contributors": [
+    "Tom Davidson <tom@tomdavidson.org> (http://tomdavidson.org)"
+  ]
 }


### PR DESCRIPTION
This simple code change requires all consumers, not just MS Windows, to set their own path to graphviz. The motivation behind decoupling tsviz from a fixed graphviz location to telling users to correctly set the path is an increase in flexibility and broader system compatibility.

closes #25 #24  #5

Thank you for tsviz and for reviewing this PR. I not quite understand  bin v src with no tsconfig.json or npm run scripts to build so I just edited both.