### PR TITLE
Allow default functions without name

### DIFF
--- a/tsviz/src/ts-analyser.ts
+++ b/tsviz/src/ts-analyser.ts
@@ -76,7 +76,8 @@ export function collectInformation(sourceFile: ts.SourceFile, program: ts.Progra
             case ts.SyntaxKind.MethodDeclaration:
             case ts.SyntaxKind.FunctionDeclaration:
                 const functionDeclaration = node as ts.FunctionDeclaration | ts.MethodDeclaration;
-                childElement = new Method((functionDeclaration.name as ts.Identifier).text, currentElement, getVisibility(node), getLifetime(node));
+                const nameText = functionDeclaration.name ? (functionDeclaration.name as ts.Identifier).text : "";
+                childElement = new Method(nameText, currentElement, getVisibility(node), getLifetime(node));
                 skipChildren = true;
                 break;
 

--- a/tsviz/src/ts-analyser.ts
+++ b/tsviz/src/ts-analyser.ts
@@ -76,7 +76,7 @@ export function collectInformation(sourceFile: ts.SourceFile, program: ts.Progra
             case ts.SyntaxKind.MethodDeclaration:
             case ts.SyntaxKind.FunctionDeclaration:
                 const functionDeclaration = node as ts.FunctionDeclaration | ts.MethodDeclaration;
-                const nameText = functionDeclaration.name ? (functionDeclaration.name as ts.Identifier).text : "";
+                const nameText = (functionDeclaration.name as ts.Identifier)?.text ?? "";
                 childElement = new Method(nameText, currentElement, getVisibility(node), getLifetime(node));
                 skipChildren = true;
                 break;


### PR DESCRIPTION
This is a great tool to gain some insight into new codebases, however currently it will not work on many new codebases, e.g. I was trying to analyze https://github.com/bluesky-social/atproto.

Problem: default functions might not have a name even though the are declared via "function".
Example:
`
export default function (server: Server) {
}
`
This fix adds a naive check to at least get some output.
This fixes https://github.com/joaompneves/tsviz/issues/46. 
